### PR TITLE
fix: rename modules of sample project for consistency

### DIFF
--- a/sample/client/build.gradle
+++ b/sample/client/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':rico-projector-common-sample')
+    implementation project(':rico-projector-sample-common')
     implementation project(':rico-projector-client')
     implementation project(':rico-projector-extension-sample-client')
 }

--- a/sample/server/build.gradle
+++ b/sample/server/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':rico-projector-common-sample')
+    implementation project(':rico-projector-sample-common')
     compile project(':rico-projector-server')
     implementation 'dev.rico:rico-remoting-server-spring:1.0.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,9 +4,9 @@ include 'rico-projector-common'
 include 'rico-projector-client'
 include 'rico-projector-server'
 
-include 'rico-projector-common-sample'
-include 'rico-projector-client-sample'
-include 'rico-projector-server-sample'
+include 'rico-projector-sample-common'
+include 'rico-projector-sample-client'
+include 'rico-projector-sample-server'
 
 include 'rico-projector-extension-sample-common'
 include 'rico-projector-extension-sample-client'
@@ -16,9 +16,9 @@ project(':rico-projector-common').projectDir=file('base/common')
 project(':rico-projector-client').projectDir=file('base/client')
 project(':rico-projector-server').projectDir=file('base/server')
 
-project(':rico-projector-common-sample').projectDir=file('sample/common')
-project(':rico-projector-client-sample').projectDir=file('sample/client')
-project(':rico-projector-server-sample').projectDir=file('sample/server')
+project(':rico-projector-sample-common').projectDir=file('sample/common')
+project(':rico-projector-sample-client').projectDir=file('sample/client')
+project(':rico-projector-sample-server').projectDir=file('sample/server')
 
 project(':rico-projector-extension-sample-common').projectDir=file('extension-sample/common')
 project(':rico-projector-extension-sample-client').projectDir=file('extension-sample/client')


### PR DESCRIPTION
-server, -client, -common should be suffixes to module names