### PR TITLE
fix: extract Rico version to central property (and upgrade to 1.0.1)

### DIFF
--- a/base/client/build.gradle
+++ b/base/client/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     implementation 'com.calendarfx:view:8.5.0'
     implementation 'com.google.guava:guava:22.0'
     testCompile 'junit:junit:4.12'
-    compile 'dev.rico:rico-remoting-client:1.0.0'
-    compile 'dev.rico:rico-remoting-client-javafx:1.0.0'
+    compile "dev.rico:rico-remoting-client:$ricoVersion"
+    compile "dev.rico:rico-remoting-client-javafx:$ricoVersion"
 }

--- a/base/common/build.gradle
+++ b/base/common/build.gradle
@@ -1,6 +1,5 @@
 
 dependencies {
-    compile 'dev.rico:rico-remoting-common:1.0.0'
+    compile "dev.rico:rico-remoting-common:$ricoVersion"
     implementation 'org.apache.commons:commons-io:1.3.2'
-//    implementation 'eu.medsea.mimeutil:mime-util:2.1.3'
 }

--- a/base/server/build.gradle
+++ b/base/server/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':rico-projector-common')
 
-    compile 'dev.rico:rico-remoting-server:1.0.0'
+    compile "dev.rico:rico-remoting-server:$ricoVersion"
     compile 'org.apache.commons:commons-lang3:3.7'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+ricoVersion=1.0.1
 version=1.0.0-SNAPSHOT

--- a/sample/server/build.gradle
+++ b/sample/server/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(':rico-projector-common-sample')
     compile project(':rico-projector-server')
-    implementation 'dev.rico:rico-remoting-server-spring:1.0.0'
+    implementation "dev.rico:rico-remoting-server-spring:$ricoVersion"
 }


### PR DESCRIPTION
to ease handling of the rico version the sample depends on, the version is now defined by a central property