### PR TITLE
build: set distribution to "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: java
 jdk: oraclejdk8


### PR DESCRIPTION
Oracle 8 is not supported in default image, so we need to stick with trusty